### PR TITLE
Allow Authentication for mongodb connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,11 @@ ENV NVM_DIR /root/.nvm
 ENV NODE_VERSION 16.15.1
 ENV MICA_BRANCH master
 
-RUN mkdir -p $NVM_DIR
-
-SHELL ["/bin/bash", "-c"]
-
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends devscripts debhelper build-essential fakeroot git && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
+    apt-get install -y --no-install-recommends devscripts debhelper build-essential fakeroot git curl
+RUN mkdir -p $NVM_DIR
+SHELL ["/bin/bash", "-c"]
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash && \
     source $NVM_DIR/nvm.sh && \
     nvm install $NODE_VERSION && \
     npm install -g bower grunt && \

--- a/bin/first_run.sh
+++ b/bin/first_run.sh
@@ -36,23 +36,6 @@ anonympw=$(echo -n $MICA_ANONYMOUS_PASSWORD | xargs java -jar /usr/share/mica2/t
 cat $MICA_HOME/conf/shiro.ini | sed -e "s/^anonymous\s*=.*/anonymous=$anonympw/" > /tmp/shiro.ini && \
     mv /tmp/shiro.ini $MICA_HOME/conf/shiro.ini
 
-# Configure MongoDB
-if [ -n "$MONGO_DB" ]
-	then
-	sed s,localhost:27017/mica,localhost:27017/$MONGO_DB,g $MICA_HOME/conf/application.yml > /tmp/application.yml
-	mv -f /tmp/application.yml $MICA_HOME/conf/application.yml
-fi
-if [ -n "$MONGO_HOST" ]
-	then
-  MGP=27017
-	if [ -n "$MONGO_PORT" ]
-	then
-		MGP=$MONGO_PORT
-	fi
-	sed s/localhost:27017/$MONGO_HOST:$MGP/g $MICA_HOME/conf/application.yml > /tmp/application.yml
-	mv -f /tmp/application.yml $MICA_HOME/conf/application.yml
-fi
-
 # Install default plugins
 if [ ! -d $MICA_HOME/plugins ]
 then

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -27,13 +27,13 @@ if [ -e /opt/mica/bin/first_run.sh ]
     mv /opt/mica/bin/first_run.sh /opt/mica/bin/first_run.sh.done
 fi
 
-# Wait for MongoDB to be ready
-if [ -n "$MONGO_HOST" ]
-	then
-	until curl -i http://$MONGO_HOST:$MONGO_PORT/mica &> /dev/null
-	do
-  		sleep 1
-	done
+#https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config
+# According to spring documentation ENV vars have precede before application.yaml properties, so we just set the value instead of fiddling with the yml file
+if [ -n "$MONGO_USERNAME" ] && [ -n "$MONGO_PASSWORD" ]
+then
+  export SPRING_DATA_MONGODB_URI=mongodb://$MONGO_USERNAME:$MONGO_PASSWORD@${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}?authSource=admin
+else
+  export SPRING_DATA_MONGODB_URI=mongodb://${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}
 fi
 
 # Start mica

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -27,13 +27,18 @@ if [ -e /opt/mica/bin/first_run.sh ]
     mv /opt/mica/bin/first_run.sh /opt/mica/bin/first_run.sh.done
 fi
 
-#https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config
-# According to spring documentation ENV vars have precede before application.yaml properties, so we just set the value instead of fiddling with the yml file
-if [ -n "$MONGO_USERNAME" ] && [ -n "$MONGO_PASSWORD" ]
+if [ -z ${MONGODB_URI+x} ]
 then
-  export SPRING_DATA_MONGODB_URI=mongodb://$MONGO_USERNAME:$MONGO_PASSWORD@${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}?authSource=admin
+  #https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config
+  # According to spring documentation ENV vars have precede before application.yaml properties, so we just set the value instead of fiddling with the yml file
+  if [ -n "$MONGO_USERNAME" ] && [ -n "$MONGO_PASSWORD" ]
+  then
+    export SPRING_DATA_MONGODB_URI=mongodb://$MONGO_USERNAME:$MONGO_PASSWORD@${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}?authSource=admin
+  else
+    export SPRING_DATA_MONGODB_URI=mongodb://${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}
+  fi
 else
-  export SPRING_DATA_MONGODB_URI=mongodb://${MONGO_HOST:-mongo}:${MONGO_PORT:-27017}/${MONGO_DB:-mica}
+export SPRING_DATA_MONGODB_URI=$MONGODB_URI
 fi
 
 # Start mica

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -27,7 +27,7 @@ if [ -e /opt/mica/bin/first_run.sh ]
     mv /opt/mica/bin/first_run.sh /opt/mica/bin/first_run.sh.done
 fi
 
-if [ -z ${MONGODB_URI+x} ]
+if [ -z $MONGODB_URI ]
 then
   #https://docs.spring.io/spring-boot/docs/1.5.6.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config
   # According to spring documentation ENV vars have precede before application.yaml properties, so we just set the value instead of fiddling with the yml file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,15 @@ services:
                         - MICA_ANONYMOUS_PASSWORD=${MICA_ANONYMOUS_PASSWORD}
                         - MONGO_HOST=mongo
                         - MONGO_PORT=27017
+                        - MONGO_DB=mica
+ #                       - MONGO_USERNAME=mica
+ #                       - MONGO_PASSWORD=${MICA_ADMINISTRATOR_PASSWORD}
                         - OPAL_URL=https://opal-demo.obiba.org
                         - AGATE_URL=https://agate-test.obiba.org
                 volumes:
                         - ${MICA_DIR}:/srv
         mongo:
                 image: mongo:6.0
+#                environment:
+#                        - MONGO_INITDB_ROOT_USERNAME=mica
+#                        - MONGO_INITDB_ROOT_PASSWORD=${MICA_ADMINISTRATOR_PASSWORD}


### PR DESCRIPTION
This adds means to configure authentication for the mongodb connections. Configuration is moved from `first_start` to each start, which allow db migration without container recreation. Further, it removes the waiting for the mongodb and fixes images creation.